### PR TITLE
📧 send email when new user register

### DIFF
--- a/devsearch/settings.py
+++ b/devsearch/settings.py
@@ -119,6 +119,14 @@ USE_I18N = True
 USE_TZ = True
 
 
+EMAIL_HOST = 'smtp.zoho.com'
+EMAIL_HOST_USER = 'ahnge226@zohomail.com'
+EMAIL_HOST_PASSWORD = 'H4GAize20T2Q'
+EMAIL_PORT = 587
+EMAIL_USE_TLS = True
+EMAIL_USE_SSL = False
+EMAIL_BACKEND = 'django.core.mail.backends.smtp.EmailBackend'
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/4.0/howto/static-files/
 

--- a/users/signals.py
+++ b/users/signals.py
@@ -1,6 +1,8 @@
 from django.db.models.signals import post_delete, post_save
 from django.dispatch import receiver
 from django.contrib.auth.models import User
+from django.core.mail import EmailMessage
+from django.conf import settings
 from .models import Profile
 
 
@@ -14,6 +16,17 @@ def create_profile(sender, instance, created, **kwargs):
             username=user.username,
             email=user.email,
             name=user.first_name)
+
+        subject = 'Welcome to Devsearch'
+        msg = "We are glad you are here!"
+        email = EmailMessage(
+            subject=subject,
+            body=msg,
+            from_email=settings.EMAIL_HOST_USER,
+            to=[profile.email],
+            headers={'Content-Type': 'text/plain'},
+        )
+        email.send()
 
 
 @receiver(post_delete, sender=Profile)


### PR DESCRIPTION
👉 configure email host, ..etc for smtp email service
👉 EMAIL_HOST_PASSWORD is included in settings but I've already deleted it. Will setup env variables when deploy.
👉 send mail with django.core.mail api when register signal trigger.